### PR TITLE
Get latest version of RR and display it.

### DIFF
--- a/scripts/latestver.js
+++ b/scripts/latestver.js
@@ -14,7 +14,11 @@ async function getRedirectedUrl(url) {
 
 async function getLatestVer(){
     const redirected = await getRedirectedUrl("https://www.github.com/Railroad-team/Railroad/releases/latest")
-    let ver = redirected.split("https://www.github.com/Railroad-team/Railroad/releases/")[1]
+    let ver = redirected.replace("https://www.github.com/Railroad-team/Railroad/releases/tag/", "")
+    
+    if (ver == undefined) {
+        ver = "1.0.0"
+    }
     
     document.getElementById('latestver').innerHTML = 'Version: ' + ver;
 }

--- a/scripts/latestver.js
+++ b/scripts/latestver.js
@@ -1,6 +1,20 @@
-function getLatestVer(){
-    let ver = '1.0.0';
-    //Todo: Find where https://www.github.com/Railroad-team/Railroad/releases/latest redirects to & then get the version
-    //From the end of the url
+async function getRedirectedUrl(url) {
+    try {
+        const response = await fetch(url, {
+            method: 'HEAD',
+            redirect: 'follow',
+        });
+
+        console.log(`Redirected to: ${response.url}`);
+        return response.url;
+    } catch (error) {
+        console.error(`Failed to fetch the URL: ${error}`);
+    }
+}
+
+async function getLatestVer(){
+    const redirected = await getRedirectedUrl("https://www.github.com/Railroad-team/Railroad/releases/latest")
+    let ver = redirected.split("https://www.github.com/Railroad-team/Railroad/releases/")[1]
+    
     document.getElementById('latestver').innerHTML = 'Version: ' + ver;
 }

--- a/scripts/latestver.js
+++ b/scripts/latestver.js
@@ -14,9 +14,9 @@ async function getRedirectedUrl(url) {
 
 async function getLatestVer(){
     const redirected = await getRedirectedUrl("https://www.github.com/Railroad-team/Railroad/releases/latest")
-    let ver = redirected.replace("https://www.github.com/Railroad-team/Railroad/releases/tag/", "")
+    let ver = redirected.replace("https://github.com/Railroad-team/Railroad/releases", "")
     
-    if (ver == undefined) {
+    if (ver == "") {
         ver = "1.0.0"
     }
     


### PR DESCRIPTION
Will currently return undefined due to it being released as pre-release I think, as /releases/latest just redirects to /releases